### PR TITLE
Using Pep518 compliant build process, reverting some meta data in setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "pybind11~=2.6.1"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -10,17 +10,8 @@ Credits:
 
 from setuptools import setup, find_packages
 
-# pybind11.readthedocs.io/en/stable/compiling.html#classic-setup-requires
-try:
-    from pybind11.setup_helpers import Pybind11Extension, build_ext
-except ImportError:
-    # If pybind11 is not installed, these are used first and in a second pass
-    # done automatically the pybind11 is then installed as the requirement
-    from setuptools import Extension as Pybind11Extension
-    build_ext = None
+from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-
-__version__ = "0.1"
 
 ext_modules = [
     Pybind11Extension(
@@ -34,14 +25,11 @@ ext_modules = [
 setup(
     name="awkde",
     version="0.1",
-    description="Common scripts for E@H post-processing",
     author="Thorben Menne",
-    author_email="thorben.menne@aei.mpg.de",
-    url="https://gitlab.aei.uni-hannover.de/thmenn/postproc",
+    author_email="thorben.menne@tu-dortmund.de",
+    url="https://github.com/mennthor/awkde",
+    description="Adaptive width gaussian KDE",
     packages=find_packages(),
-    setup_requires=[
-        "pybind11",  # For this install script
-    ],
     install_requires=["numpy", "scipy", "scikit-learn", "pybind11", "future"],
     ext_modules=ext_modules,  # Compiled external modules
     cmdclass={


### PR DESCRIPTION
Updating to current recommended pybind11 build method using a pyproject.toml: https://pybind11.readthedocs.io/en/latest/compiling.html#pep-518-requirements-pip-10-required