### PR TITLE
Try fixing build under Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11~=2.6.1"]
+requires = ["setuptools>=42", "wheel", "pybind11"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Hello. Building on Python 3.11 fails with the error visible in [1] and [2]. I am not sure why the pybind11 version was being forced to 2.6.x, but removing the pin fixes the error, and the example works with the resulting build.

[1] [awkde_error.txt](https://github.com/mennthor/awkde/files/10545892/awkde_error.txt)
[2] https://github.com/gwastro/pycbc/pull/4243